### PR TITLE
Debug turbopack path error

### DIFF
--- a/ecucondor-app/next.config.ts
+++ b/ecucondor-app/next.config.ts
@@ -1,10 +1,6 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  // Configuración de Turbopack
-  turbopack: {
-    root: '/home/edu/ECUCONDORULTIMATE/ecucondor-app',
-  },
   // Optimizaciones de imagen
   images: {
     domains: ['ecucondor.com'],


### PR DESCRIPTION
Remove hardcoded Turbopack root path from `next.config.ts` to fix `FileSystemPath` error on Windows.

The hardcoded `turbopack.root` was set to a Linux path (`/home/edu/...`), which caused a `FileSystemPath("").join(...) leaves the filesystem root` error when running `npm run dev` on Windows. Removing this configuration allows Next.js to correctly infer the project root.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe4e673d-7aaa-4c9d-a579-ada1c0361c60">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fe4e673d-7aaa-4c9d-a579-ada1c0361c60">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

